### PR TITLE
Suggest magento-hackathon composer installer instead of requiring it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "magento-module",
     "description": "Phoenix Media WorldPay magento module",
     "homepage": "https://github.com/PHOENIX-MEDIA/Magento-WorldPay",
-    "require": {
+    "suggest": {
         "magento-hackathon/magento-composer-installer": "1.3.1"
     }
 }


### PR DESCRIPTION
Based on the documentation here.

https://github.com/Cotya/magento-composer-installer/blob/master/doc/FAQ.md

**Should my module require the Installer**

 No, it should not. But it can suggest using it (same syntax as require, but you use "suggest" instead of "require"."

This PR correctly does what is attempted in https://github.com/PHOENIX-MEDIA/Magento-WorldPay/pull/11