### PR TITLE
Changed `gethostbyaddr` to ip range

### DIFF
--- a/app/code/community/Phoenix/Worldpay/controllers/ProcessingController.php
+++ b/app/code/community/Phoenix/Worldpay/controllers/ProcessingController.php
@@ -167,7 +167,12 @@ class Phoenix_Worldpay_ProcessingController extends Mage_Core_Controller_Front_A
             $request = $this->getRequest()->getServer();
             $remoteAddr = $request['REMOTE_ADDR'];
         }
-        if (!preg_match('/\.worldpay\.com$/', gethostbyaddr($remoteAddr))) {
+        //Worldpay IPs.
+        $high_ip = ip2long('195.35.91.255');
+        $low_ip = ip2long('195.35.90.0');
+        $ip= ip2long($remoteAddr);
+        //if request ip is outside the above range, then not come from WorldPay.
+        if ($ip < $low_ip || $ip > $high_ip) {
             Mage::throwException('Domain can\'t be validated as WorldPay-Domain.');
         }
 


### PR DESCRIPTION
Callbacks from WorldPay may come from any IP in the range 195.35.90.0 to 195.35.91.255. For many of these, `gethostbyaddr` returns the IP address, not a worldpay.com domain name (e.g. the Hostname value for 195.35.90.0 is 195.35.90.0 - https://whatismyipaddress.com/ip/195.35.90.0). This means that WorldPay is accepting the payment, performing the callback and failing! Orders in Magento are being listed as 'pending_payment' instead of changing to 'complete'.

This patch replaces `gethostbyaddr` with a conditional check of the IPs.